### PR TITLE
ci: configure self-hosted Renovate action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,11 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:base"],
+  lockFileMaintenance: {
+    enabled: true,
+    extends: ["schedule:weekly"]
+  },
+  nix: {
+    enabled: true
+  }
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,17 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:base"],
+  onboarding: false,
+  requireConfig: false,
+  branchPrefix: "renovate-remi-gelinas/",
+  username: "renovate-remi-gelinas[bot]",
+  gitAuthor: "Renovate <132273073+renovate-remi-gelinas[bot]@users.noreply.github.com>",
   lockFileMaintenance: {
     enabled: true,
-    extends: ["schedule:weekly"]
   },
+  enabledManagers: [
+    "nix",
+    "github-actions"
+  ],
   nix: {
     enabled: true
   }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 9 * * FRI'
+    - cron: '0 13 * * FRI'
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,24 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 9 * * FRI'
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@v1
+        with:
+          private_key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          app_id: ${{ secrets.RENOVATE_APP_ID }}
+
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+
+      - name: Run self-hosted Renovate
+        uses: renovatebot/github-action@v36.0.0
+        with:
+          configurationFile: .github/renovate.json5
+          token: '${{ steps.get_token.outputs.token }}'


### PR DESCRIPTION
Add a Github workflow to run a self-hosted Renovate action at 9:00AM EST every Friday, to update actions and Nix flake inputs.