### PR TITLE
ci: run Renovate on manual trigger

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,5 +1,6 @@
 name: Renovate
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 13 * * FRI'
 


### PR DESCRIPTION
Configure the `Renovate` action to run when manually triggered as well as on its schedule.